### PR TITLE
fix: adds apple touch icon link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,8 @@
 
 	<title>VOIP Flashcards (by @tom_armitage)</title>
 
-	<link rel='icon' type='image/png' href='/favicon.png'>
+  <link rel='icon' type='image/png' href='/favicon.png'>
+  <link rel="apple-touch-icon" href="/favicon.png">
 	<link rel='stylesheet' href='/global.css'>
   <link rel='stylesheet' href='/build/bundle.css'>
   <link rel="manifest" href="/manifest.webmanifest">


### PR DESCRIPTION
Now, when you add it to your iOS home screen, it will use the favicon as the icon.

![image](https://user-images.githubusercontent.com/265638/76879807-c6c3b180-6844-11ea-81f0-4f2d879ec4fe.png)
