### PR TITLE
Add "My mic's not working"

### DIFF
--- a/data/voipcards.json
+++ b/data/voipcards.json
@@ -27,6 +27,8 @@
     "en": [
       {"label": "Thanks!"},
       {"label": "You're on mute."},
+      {"label": "I'm stuck on mute."},
+      {"label": "My mic's not working."},
       {"label": "Everyone is talking."},
       {"label": "One at a time."},
       {"label": "I'd like to speak."},


### PR DESCRIPTION
On video calls I think a common thing to be trying to convey by camera is _"I'm stuck on mute"_ or _"My mic's not working"_.
The more full message would be  _"Sorry. My mic's not working. Wait a sec while I try to fix it"_ (but obviously that's too long).